### PR TITLE
add svg image generation for geos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ Available geographies are as follows:
 `neighborhoods`
 `counties`
 
-These can be substituted anywhere a url references a path segment `:geo-name`
+These can be substituted anywhere a url references a path segment `{geography}`
 
 
 Text Search
 ---
 
-`geographies/:geo-name?search={query}`
+`geographies/{geography}?search={query}`
 
 Geographies can be searched via text to match against all attributes. This is
 helpful as the property names for certain geographies can be very specific in nature
 to the geography or datasource. For instance, a common 5-digit US postal code is contained
 in the property `properties.ZCTA5CE10` in the `postal-codes` geography. In order to not keep
 track of specific collection-based common names like `ZCTA5CE10`, a search paramter is used on
-the `geographies/:geo-name` endpoint to search all text fields for a url query `?search`.
+the `geographies/{geography}` endpoint to search all text fields for a url query `?search`.
 
 Example:
 
@@ -47,7 +47,7 @@ curl -H 'Accept: application/json' http://boundaries.io/geographies/postal-codes
 Where Am I?
 ---
 
-`geographies/:geo-name/whereami?lat={latitude}&lng={longitude}`
+`geographies/{geography}/whereami?lat={latitude}&lng={longitude}`
 
 When querying the `whereami` endpoint, the geography that contains the provided latitude/longitude pair will be returned if found.
 For instance, when requesting `geographies/postal-codes/whereami?lat=36.011616617997426&lng=-78.9103317260742`,
@@ -66,7 +66,7 @@ curl -H 'Accept: application/json' http://boundaries.io/geographies/postal-codes
 Named
 ---
 
-`geographies/:geo-name/named/{name}`
+`geographies/{geography}/named/{name}`
 
 The typical name key for geographies from the US Census TIGER shapefiles is `properties.NAME`, but for postal-codes is
 `properties.ZCTA5CE10`. Geographies can be queried against the identifying key with the `named` endpoint.
@@ -80,11 +80,28 @@ curl -H 'accept: application/json' http://boundaries.io/geographies/postal-codes
 curl -H 'accept: application/json' http://boundaries.io/geographies/states/named/north%20carolina
 ```
 
+Named (SVG Image)
+---
+
+`geographies/{geography}/named/{name}.svg`
+
+Parameters:
+
+`width`, `height`, `stroke`, `fill`
+
+Example:
+
+```
+curl http://boundaries.io/geographies/states/named/north%20carolina.svg
+# => <svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+#        <path d="M64.0623532378737,21.511595932804283
+```
+
 
 Near Me
 ---
 
-`geographies/:geo-name/nearme?lat={latitude}&lng={longitude}`
+`geographies/{geography}/nearme?lat={latitude}&lng={longitude}`
 
 Similar to the `whereami` endpoint, one can query the nearby geographies with the `nearme` endpoint. Simply provide a lat/lng
 

--- a/app/controllers/geographies-controller.js
+++ b/app/controllers/geographies-controller.js
@@ -1,4 +1,7 @@
 var ApplicationController = require('./application-controller');
+var geojson2svg = require('geojson2svg');
+var reproject = require('reproject-spherical-mercator');
+var geojsonExtent = require('geojson-extent');
 
 var GeographiesController = ApplicationController.extend({
 
@@ -37,22 +40,57 @@ var GeographiesController = ApplicationController.extend({
     var geo = yield this.geos.findOne({
       _id: this.mongo._db.bsonLib.ObjectID(this.params.id)
     });
-    this.set('geography', geo);
+
+    this.set({
+      geography: geo,
+      renderer: this.getGeojsonSvgConverter(geo, 300, 300)
+    });
+
     yield this.respondWith(geo);
   },
 
+  svg: function* () {
+
+    var geo;
+    var geometry;
+    var width = this.params.width || 300;
+    var height = this.params.height || 300;
+
+    geo = yield this.findByName(this.params.name);
+    renderer = this.getGeojsonSvgConverter(geo, {
+      width: width,
+      height: height
+    });
+
+    this.render = false;
+    this.ctx.type = 'image/svg+xml';
+
+    this.body = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+        ${renderer.converter.convert(renderer.geometry).join('')}
+      </svg>
+    `;
+  },
+
   named: function* () {
-    var criteria = {};
-    var thenable;
-    criteria[this.nameKey] = new RegExp(this.params.name, 'i');
-    try {
-      thenable = this.geos.findOne(criteria);
-    } catch (e) {}
-    if (thenable) {
-      yield this.respondWith(thenable);
-    } else {
-      this.throw(404);
+    var geo = yield this.findByName(this.params.name);
+
+    if (!geo) {
+      return this.throw(404);
     }
+
+    this.set({
+      geography: geo,
+      renderer: this.getGeojsonSvgConverter(geo, 300, 300),
+      nameKey: this.nameKey
+    });
+
+    yield this.respondTo({
+      html: function* () {},
+      json: function* () {
+        this.body = geo;
+      }
+    });
   },
 
   whereami: function* () {
@@ -63,6 +101,49 @@ var GeographiesController = ApplicationController.extend({
   nearme: function* () {
     var thenable = this.near(this.params.lat, this.params.lng);
     yield this.respondWith(thenable);
+  },
+
+  getGeojsonSvgConverter: function(geo, options) {
+    options || (options = {});
+    var width = options.width || 300;
+    var height = options.height || 300;
+    var geometry = reproject(geo.geometry);
+    var extentTuple = geojsonExtent(geometry);
+    var extent;
+    var converter;
+
+    extent = {
+      left: extentTuple[0],
+      bottom: extentTuple[1],
+      right: extentTuple[2],
+      top: extentTuple[3]
+    };
+
+    converter = geojson2svg({
+      viewportSize: {
+        width: width,
+        height: height
+      },
+      output: 'svg',
+      mapExtent: extent,
+      attributes: {
+        stroke: this.params.stroke || 'none',
+        fill: this.params.fill || 'black'
+      },
+      explode: true
+    });
+
+    return {
+      converter: converter,
+      geometry: geometry,
+      extent: extent
+    };
+  },
+
+  findByName: function* (name) {
+    var criteria = {};
+    criteria[this.nameKey] = new RegExp(this.params.name, 'i');
+    return yield this.geos.findOne(criteria);
   },
 
   at: function* (lat, lng, options) {

--- a/app/views/geographies/named.html
+++ b/app/views/geographies/named.html
@@ -1,0 +1,20 @@
+{% extends '../layouts/application.html' %}
+
+{% block content %}
+
+<br><br>
+<h2>{{ geography.properties[nameKey.split('.')[1]] }}</h2>
+<hr>
+
+<div class="row">
+  <div class="small-6 columns">
+    <pre><code>{{ geography.properties | json(2) }}</code></pre>
+  </div>
+  <div class="small-6 columns">
+    <svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+      {{ renderer.converter.convert(renderer.geometry) }}
+    </svg>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/geographies/named.html
+++ b/app/views/geographies/named.html
@@ -3,14 +3,19 @@
 {% block content %}
 
 <br><br>
-<h2>{{ geography.properties[nameKey.split('.')[1]] }}</h2>
+<div class="row">
+  <div class="small-12">
+    <h2>{{ geography.properties[nameKey.split('.')[1]] }}</h2>
+  </div>
+</div>
+
 <hr>
 
 <div class="row">
-  <div class="small-6 columns">
+  <div class="small-12 medium-6 columns">
     <pre><code>{{ geography.properties | json(2) }}</code></pre>
   </div>
-  <div class="small-6 columns">
+  <div class="small-12 medium-6 columns">
     <svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
       {{ renderer.converter.convert(renderer.geometry) }}
     </svg>

--- a/config/application.js
+++ b/config/application.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
     reduction = (1 - Math.round((after / before) * 100) / 100)
     // this.ctx.set('X-Topojson-Reduction', reduction > 0 ? reduction : 0);
 
-    return yield topology;
+    return yield Promise.resolve(topology);
   });
 
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -12,6 +12,7 @@ module.exports = function(router) {
     router.get('/geographies/' + geo + '/whereami').to('geographies/' + geo + '.whereami');
     router.get('/geographies/' + geo + '/nearme').to('geographies/' + geo + '.nearme');
     router.get('/geographies/' + geo + '/named/:name').to('geographies/' + geo + '.named');
+    router.get('/geographies/' + geo + '/named/:name.svg').to('geographies/' + geo + '.svg');
     router.resource('geographies/' + geo);
   });
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "boundaries.io",
   "version": "0.4.1",
   "dependencies": {
+    "geojson-extent": "0.3.2",
+    "geojson2svg": "1.0.3",
     "koa-compress": "1.0.8",
     "kona": "^0.10.4",
     "kona-mongo": "^1.0.0",
     "marked": "^0.3.5",
+    "reproject-spherical-mercator": "0.1.3",
     "topojson": "^1.6.19"
   },
   "devDependencies": {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -89,6 +89,26 @@ describe('boundaries.io', function() {
           })
           .end(done);
       });
+
+      describe('.svg', function() {
+
+        it('returns an svg string of the geometry', function(done) {
+
+          var path = '/geographies/postal-codes/named/' + postalcode.properties['GEOID10'] + '.svg';
+
+          agent
+            .get(path)
+            .expect(200)
+            .expect('content-type', 'image/svg+xml')
+            .expect(function(res) {
+              expect(res.body.toString()).to.contain('M137.69088842490171,190.79525229527445');
+            })
+            .end(done);
+
+        });
+
+      });
+
     });
 
   });


### PR DESCRIPTION
Found some useful tools that made this easy:

[geojson2svg](https://github.com/gagan-bansal/geojson2svg)
[reproject-spherical-mercator](https://github.com/geosquare/reproject-spherical-mercator)
[geojson-extent](https://github.com/mapbox/geojson-extent)

- .svg extension to the `named/:name` path will return SVG string
- parameters can be provided: width, height, stroke, fill
- geojson must be in mercator sphere projection, not WGS for the tools
  used
- also added a named html page since it seemed appropriate and I'm tired
  of getting 404s when requesting via a browser

---

Named (SVG Image)
---

`geographies/{geography}/named/{name}.svg`

Parameters:

`width`, `height`, `stroke`, `fill`

Example:

```
curl http://boundaries.io/geographies/states/named/north%20carolina.svg
# => <svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
#        <path d="M64.0623532378737,21.511595932804283
```

<img width="527" alt="screen shot 2016-08-15 at 9 26 01 pm" src="https://cloud.githubusercontent.com/assets/1413330/17685086/e4fa6a78-632e-11e6-8e7c-5b30cfe0519b.png">
<img width="973" alt="screen shot 2016-08-15 at 9 27 52 pm" src="https://cloud.githubusercontent.com/assets/1413330/17685123/28adc77e-632f-11e6-8d7c-ae2275ebb75b.png">
